### PR TITLE
改变代码块样式解决覆盖头像小Bug

### DIFF
--- a/app/assets/stylesheets/front.scss
+++ b/app/assets/stylesheets/front.scss
@@ -437,7 +437,7 @@
     border: 0px;
     border-top: 1px solid #f0f0f0;
     border-bottom: 1px solid #f0f0f0;
-    margin: 0 -15px 15px -15px;
+    margin: 0 -15px 15px 0px;
     padding: 5px 15px;
     color: #444;
     overflow: auto;


### PR DESCRIPTION
设置margin-left为0px，解决帖子回复直接代码块覆盖头像的问题。

![image](https://cloud.githubusercontent.com/assets/6478167/18613062/7fdcf400-7da3-11e6-895f-484686585bb4.png)
